### PR TITLE
Unify edit behavior by creating a component for string attributes

### DIFF
--- a/src/components/AreaBox.vue
+++ b/src/components/AreaBox.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { defineProps, ref, watch } from "vue";
 import { updateArea } from "@/ts/area-rest-client";
-
 import { IArea } from "@/ts/models";
 import { useToast } from "vue-toastification";
+import EditableStringAttribute from "@/components/EditableStringAttribute.vue";
 
 const props = defineProps<{
   area: IArea;
@@ -15,8 +15,6 @@ const props = defineProps<{
 const toast = useToast();
 
 const area = ref(props.area);
-ref(Array<boolean>());
-const editingAreaLecturerName = ref();
 
 watch(
   () => props.area,
@@ -26,30 +24,24 @@ watch(
   { deep: true }
 );
 
-function startEditAreaLecturerName(editingArea: IArea) {
-  editingAreaLecturerName.value = editingArea.topicName;
-}
-
-function saveEditAreaLecturerName(editedArea: IArea) {
-  editedArea.topicName = editingAreaLecturerName.value;
-  updateArea(props.courseId, props.worldIndex, props.dungeonIndex, editedArea)
+function saveTopicName(topicName: string) {
+  area.value.topicName = topicName;
+  updateArea(props.courseId, props.worldIndex, props.dungeonIndex, area.value)
     .then((response) => {
-      editedArea = response.data;
+      area.value = response.data;
     })
     .catch((error) => {
       console.log(error);
     });
-  editedArea.topicName = editingAreaLecturerName.value;
   toast.success(
-    `Topic name of lecture ${editedArea.staticName} was updated to ${editedArea.topicName}!`
+    `Topic name of course ${area.value.staticName} was updated to ${area.value.topicName}!`
   );
-
-  editingAreaLecturerName.value = null;
 }
 
-function cancelEditAreaLecturerName(editedArea: IArea) {
-  toast.warning(`Name of lecture ${editedArea.staticName} was not updated!`);
-  editingAreaLecturerName.value = null;
+function cancelEditTopicName() {
+  toast.warning(
+    `Topic name of course ${area.value.staticName} was not updated!`
+  );
 }
 
 function toggledAreaSwitch(toggledArea: IArea) {
@@ -75,41 +67,12 @@ function toggledAreaSwitch(toggledArea: IArea) {
     <h5>{{ area.staticName }}</h5>
   </b-td>
   <b-td id="area-name-column">
-    <div v-if="editingAreaLecturerName == null">
-      <h4>
-        {{ area.topicName }}
-        <b-button
-          variant="light"
-          size="small"
-          @click="startEditAreaLecturerName(area)"
-        >
-          <em class="bi bi-pencil-square"></em>
-        </b-button>
-      </h4>
-    </div>
-    <div v-else>
-      <b-input-group>
-        <b-col sm="8">
-          <b-form-input v-model="editingAreaLecturerName"></b-form-input>
-        </b-col>
-        <b-button-group>
-          <b-button
-            variant="success"
-            size="sm"
-            @click="saveEditAreaLecturerName(area)"
-          >
-            <em class="bi bi-journal-check"></em>
-          </b-button>
-          <b-button
-            variant="danger"
-            size="sm"
-            @click="cancelEditAreaLecturerName(area)"
-          >
-            <em class="bi bi-x-lg"></em>
-          </b-button>
-        </b-button-group>
-      </b-input-group>
-    </div>
+    <EditableStringAttribute
+      :prefix="null"
+      :value="area.topicName"
+      @submit="saveTopicName"
+      @cancel="cancelEditTopicName"
+    />
   </b-td>
   <b-td>
     <b-form-checkbox

--- a/src/components/EditableStringAttribute.vue
+++ b/src/components/EditableStringAttribute.vue
@@ -2,7 +2,7 @@
 import { defineProps, defineEmits, ref, watch } from "vue";
 
 const props = defineProps<{
-  value: string;
+  value: string | null;
   prefix: string | null;
 }>();
 

--- a/src/components/EditableStringAttribute.vue
+++ b/src/components/EditableStringAttribute.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { defineProps, defineEmits, ref, watch } from "vue";
+
+const props = defineProps<{
+  value: string;
+  prefix: string | null;
+}>();
+
+const prefix = ref(props.prefix);
+const value = ref(props.value);
+const editing = ref(false);
+const editingValue = ref();
+
+watch(
+  () => props.value,
+  (newValue) => {
+    value.value = newValue;
+  },
+  { deep: true }
+);
+
+watch(
+  () => props.prefix,
+  (newPrefix) => {
+    prefix.value = newPrefix;
+  },
+  { deep: true }
+);
+
+const emit = defineEmits<{
+  (e: "submit", value: string): void;
+  (e: "cancel"): void;
+}>();
+
+function startEdit() {
+  editingValue.value = value.value;
+  editing.value = true;
+}
+
+function saveEdit() {
+  emit("submit", editingValue.value);
+  editing.value = false;
+  editingValue.value = value.value;
+}
+
+function cancelEdit() {
+  emit("cancel");
+  editing.value = false;
+  editingValue.value = value.value;
+}
+</script>
+
+<template>
+  <h5 v-if="!editing">
+    <span v-if="prefix != null">{{ prefix }}: </span>{{ value }}
+    <b-button variant="light" size="small" @click="startEdit">
+      <em class="bi bi-pencil-square"></em>
+    </b-button>
+  </h5>
+  <b-col sm="6" v-else>
+    <b-form @submit="saveEdit" @cancel="cancelEdit">
+      <b-input-group :prepend="prefix">
+        <b-form-input v-model="editingValue"></b-form-input>
+        <b-button variant="success" type="submit" size="sm" @click="saveEdit">
+          <em class="bi bi-journal-check"></em>
+        </b-button>
+        <b-button variant="danger" size="sm" type="reset" @click="cancelEdit">
+          <em class="bi bi-x-lg"></em>
+        </b-button>
+      </b-input-group>
+    </b-form>
+  </b-col>
+</template>

--- a/src/views/CourseView.vue
+++ b/src/views/CourseView.vue
@@ -3,13 +3,11 @@ import { getCourse, putCourse } from "@/ts/course-rest-client";
 import { ref } from "vue";
 import { useRoute } from "vue-router";
 import { useToast } from "vue-toastification";
+import EditableStringAttribute from "@/components/EditableStringAttribute.vue";
 
 const route = useRoute();
 const id = route.params.id as string;
 const course = ref();
-const editingCourseName = ref();
-const editingDescription = ref();
-const editingSemester = ref();
 
 async function loadCourse(stringId: string) {
   console.log("load course");
@@ -34,12 +32,8 @@ loadCourse(id);
 
 const toast = useToast();
 
-function startEditCourseName() {
-  editingCourseName.value = course.value.courseName;
-}
-
-function saveEditCourseName() {
-  course.value.courseName = editingCourseName.value;
+function saveCourseName(courseName: string) {
+  course.value.courseName = courseName;
   putCourse(course.value)
     .then((response) => {
       course.value = response.data;
@@ -53,20 +47,14 @@ function saveEditCourseName() {
         `Name of course ${course.value.courseName} could not be updated!`
       );
     });
-  editingCourseName.value = null;
 }
 
 function cancelEditCourseName() {
-  toast.warning(`Name of course ${course.value.courseName} was not updated!`);
-  editingCourseName.value = null;
+  toast.warning(`Name of course ${course.value.description} was not updated!`);
 }
 
-function startEditDescription() {
-  editingDescription.value = course.value.description;
-}
-
-function saveEditDescription() {
-  course.value.description = editingDescription.value;
+function saveDescription(description: string) {
+  course.value.description = description;
   putCourse(course.value)
     .then((response) => {
       course.value = response.data;
@@ -80,22 +68,16 @@ function saveEditDescription() {
         `Description of course ${course.value.courseName} could not be updated!`
       );
     });
-  editingDescription.value = null;
 }
 
 function cancelEditDescription() {
   toast.warning(
     `Description of course ${course.value.description} was not updated!`
   );
-  editingDescription.value = null;
 }
 
-function startEditSemester() {
-  editingSemester.value = course.value.semester;
-}
-
-function saveEditSemester() {
-  course.value.semester = editingSemester.value;
+function saveSemester(semester: string) {
+  course.value.semester = semester;
   putCourse(course.value)
     .then((response) => {
       course.value = response.data;
@@ -110,16 +92,14 @@ function saveEditSemester() {
       );
       loadCourse(id);
     });
-
-  editingSemester.value = null;
 }
 
 function cancelEditSemester() {
   toast.warning(
     `Semester of course ${course.value.courseName} was not updated!`
   );
-  editingSemester.value = null;
 }
+
 function toggleCourseSwitch() {
   putCourse(course.value).then((response) => {
     course.value = response.data;
@@ -138,121 +118,31 @@ function toggleCourseSwitch() {
   <div class="container mt-4">
     <div v-if="course != null" class="">
       <b-col>
-        <div v-if="editingCourseName == null">
-          <h1>
-            Course name: {{ course.courseName }}
-            <b-button
-              id="course-name-edit"
-              variant="light"
-              size="small"
-              @click="startEditCourseName"
-            >
-              <em class="bi bi-pencil-square"></em>
-            </b-button>
-          </h1>
-        </div>
-        <div v-else>
-          <b-row>
-            <b-col>
-              <b-form-input
-                id="course-name-input"
-                v-model="editingCourseName"
-              ></b-form-input>
-            </b-col>
-            <b-col>
-              <b-button-group>
-                <b-button
-                  variant="success"
-                  size="sm"
-                  @click="saveEditCourseName"
-                >
-                  <em class="bi bi-journal-check"></em>
-                </b-button>
-                <b-button
-                  variant="danger"
-                  size="sm"
-                  @click="cancelEditCourseName"
-                >
-                  <em class="bi bi-x-lg"></em>
-                </b-button>
-              </b-button-group>
-            </b-col>
-          </b-row>
-        </div>
+        <EditableStringAttribute
+          prefix="Name"
+          :value="course.courseName"
+          @submit="saveCourseName"
+          @cancel="cancelEditCourseName"
+          id="course-name"
+        />
       </b-col>
       <b-col>
-        <div v-if="editingDescription == null">
-          <h5>
-            description: {{ course.description }}
-            <b-button
-              id="course-description-edit"
-              variant="light"
-              size="small"
-              @click="startEditDescription"
-            >
-              <em class="bi bi-pencil-square"></em>
-            </b-button>
-          </h5>
-        </div>
-        <div v-else>
-          <b-row>
-            <b-col>
-              <b-form-input
-                id="course-description-input"
-                v-model="editingDescription"
-              ></b-form-input>
-            </b-col>
-            <b-col>
-              <b-button-group>
-                <b-button
-                  variant="success"
-                  size="sm"
-                  @click="saveEditDescription"
-                >
-                  <em class="bi bi-journal-check"></em>
-                </b-button>
-                <b-button
-                  variant="danger"
-                  size="sm"
-                  @click="cancelEditDescription"
-                >
-                  <em class="bi bi-x-lg"></em>
-                </b-button>
-              </b-button-group>
-            </b-col>
-          </b-row>
-        </div>
+        <EditableStringAttribute
+          prefix="Description"
+          :value="course.description"
+          @submit="saveDescription"
+          @cancel="cancelEditDescription"
+          id="course-description"
+        />
       </b-col>
       <b-col>
-        <div v-if="editingSemester == null">
-          <h5>
-            semester: {{ course.semester }}
-            <b-button variant="light" size="small" @click="startEditSemester">
-              <em class="bi bi-pencil-square"></em>
-            </b-button>
-          </h5>
-        </div>
-        <div v-else>
-          <b-row>
-            <b-col>
-              <b-form-input v-model="editingSemester"></b-form-input>
-            </b-col>
-            <b-col>
-              <b-button-group>
-                <b-button variant="success" size="sm" @click="saveEditSemester">
-                  <em class="bi bi-journal-check"></em>
-                </b-button>
-                <b-button
-                  variant="danger"
-                  size="sm"
-                  @click="cancelEditSemester"
-                >
-                  <em class="bi bi-x-lg"></em>
-                </b-button>
-              </b-button-group>
-            </b-col>
-          </b-row>
-        </div>
+        <EditableStringAttribute
+          prefix="Semester"
+          :value="course.semester"
+          @submit="saveSemester"
+          @cancel="cancelEditSemester"
+          id="course-semester"
+        />
       </b-col>
       <b-col>
         <h4>active:</h4>

--- a/src/views/WorldView.vue
+++ b/src/views/WorldView.vue
@@ -64,7 +64,6 @@ watch(
               :courseId="courseId"
               :worldIndex="world.index"
               :dungeonIndex="0"
-              @editMinigameConfiguration="editMinigameConfiguration"
             />
           </b-tr>
           <b-tr v-for="dungeon in world.dungeons" :key="dungeon.id">
@@ -73,7 +72,6 @@ watch(
               :courseId="courseId"
               :worldIndex="world.index"
               :dungeonIndex="dungeon.index"
-              @editMinigameConfiguration="editMinigameConfiguration"
             />
           </b-tr>
         </b-tbody>

--- a/tests/unit/CourseView.spec.ts
+++ b/tests/unit/CourseView.spec.ts
@@ -3,8 +3,9 @@ import mockAxios from "jest-mock-axios";
 import router from "@/router/index";
 import CourseView from "@/views/CourseView.vue";
 import { Course, ICourse } from "@/ts/models";
-import BootstrapVue3 from "bootstrap-vue-3";
+import BootstrapVue3, { BButton, BFormInput } from "bootstrap-vue-3";
 import config from "@/config";
+import EditableStringAttribute from "@/components/EditableStringAttribute.vue";
 
 jest.mock("axios");
 
@@ -49,8 +50,17 @@ describe("CourseView.vue", () => {
 
     const updatedCourseName = "New Course XY";
 
-    let editCourseNameButton = wrapper.find("#course-name-edit");
-    let editCourseNameInput = wrapper.find("#course-name-input");
+    const stringEditComponent = wrapper
+      .findAllComponents(EditableStringAttribute)
+      .find((component) => component.attributes().id == "course-name");
+    expect(stringEditComponent != null).toBe(true);
+
+    if (stringEditComponent == null) {
+      return;
+    }
+
+    let editCourseNameButton = stringEditComponent.findComponent(BButton);
+    let editCourseNameInput = stringEditComponent.findComponent(BFormInput);
     expect(editCourseNameButton.exists()).toBe(true);
     expect(editCourseNameInput.exists()).toBe(false);
     expect(wrapper.html()).toContain(initialCourseName);
@@ -60,7 +70,7 @@ describe("CourseView.vue", () => {
     // wait that component re-renders
     await flushPromises();
 
-    editCourseNameInput = wrapper.find("#course-name-input");
+    editCourseNameInput = stringEditComponent.findComponent(BFormInput);
     expect(editCourseNameInput.exists()).toBe(true);
     editCourseNameInput.setValue(updatedCourseName);
 
@@ -72,8 +82,8 @@ describe("CourseView.vue", () => {
     // wait that component re-renders
     await flushPromises();
 
-    editCourseNameButton = wrapper.find("#course-name-edit");
-    editCourseNameInput = wrapper.find("#course-name-input");
+    editCourseNameButton = stringEditComponent.findComponent(BButton);
+    editCourseNameInput = stringEditComponent.findComponent(BFormInput);
     expect(editCourseNameButton.exists()).toBe(true);
     expect(editCourseNameInput.exists()).toBe(false);
     expect(wrapper.html()).toContain(updatedCourseName);
@@ -88,8 +98,19 @@ describe("CourseView.vue", () => {
 
     const updatedCourseDescription = "New Course XY";
 
-    let editCourseDescriptionButton = wrapper.find("#course-description-edit");
-    let editCourseDescriptionInput = wrapper.find("#course-description-input");
+    const stringEditComponent = wrapper
+      .findAllComponents(EditableStringAttribute)
+      .find((component) => component.attributes().id == "course-description");
+    expect(stringEditComponent != null).toBe(true);
+
+    if (stringEditComponent == null) {
+      return;
+    }
+
+    let editCourseDescriptionButton =
+      stringEditComponent.findComponent(BButton);
+    let editCourseDescriptionInput =
+      stringEditComponent.findComponent(BFormInput);
     expect(editCourseDescriptionButton.exists()).toBe(true);
     expect(editCourseDescriptionInput.exists()).toBe(false);
     expect(wrapper.html()).toContain(initialCourseDescription);
@@ -99,7 +120,7 @@ describe("CourseView.vue", () => {
     // wait that component re-renders
     await flushPromises();
 
-    editCourseDescriptionInput = wrapper.find("#course-description-input");
+    editCourseDescriptionInput = stringEditComponent.findComponent(BFormInput);
     expect(editCourseDescriptionInput.exists()).toBe(true);
     editCourseDescriptionInput.setValue(updatedCourseDescription);
 
@@ -111,8 +132,8 @@ describe("CourseView.vue", () => {
     // wait that component re-renders
     await flushPromises();
 
-    editCourseDescriptionButton = wrapper.find("#course-description-edit");
-    editCourseDescriptionInput = wrapper.find("#course-description-input");
+    editCourseDescriptionButton = stringEditComponent.findComponent(BButton);
+    editCourseDescriptionInput = stringEditComponent.findComponent(BFormInput);
     expect(editCourseDescriptionButton.exists()).toBe(true);
     expect(editCourseDescriptionInput.exists()).toBe(false);
     expect(wrapper.html()).toContain(updatedCourseDescription);


### PR DESCRIPTION
Created a new component named `EditableStringAttribute` which allows to display an attribute and edit it by pressing an edit button which displays an input field.

To make sure the bug is fixed try it with a course which has null value as description.
Also it would be nice if following test-plans were executed to check functionallity:
- https://github.com/Gamify-IT/docs/blob/main/dev-manuals/test-plans/lecturer-interface/u-lecturer-interface-04-edit-course-name.md
- https://github.com/Gamify-IT/docs/blob/main/dev-manuals/test-plans/lecturer-interface/u-lecturer-interface-05-edit-course-description.md
- https://github.com/Gamify-IT/docs/blob/main/dev-manuals/test-plans/lecturer-interface/u-lecturer-interface-06-edit-course-semester.md
- https://github.com/Gamify-IT/docs/blob/main/dev-manuals/test-plans/lecturer-interface/u-lecturer-interface-09-edit-area-topic-name.md

Closes Gamify-IT/issues#213
Make attribute input apply by hitting enter as part of Gamify-IT/issues#217