### PR TITLE
Remove v-if condition on showing map image modal

### DIFF
--- a/src/components/MapImageModal.vue
+++ b/src/components/MapImageModal.vue
@@ -80,7 +80,6 @@ function getImage(): string {
     size="xl"
     v-model="showModal"
     @hidden="hiddenModal"
-    v-if="showModal"
   >
     <b-img :src="getImage()" fluid></b-img>
   </b-modal>


### PR DESCRIPTION
With the v-if condition, the hidden event does not trigger, this leads to not emit `closedModal`. This is followed by the fact that a modal can only be opened once and then no longer