### PR TITLE
Add minigame statistic view with general statistics and first statistic support for finitequiz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "vue-router": "^4.0.3",
         "vue-sidebar-menu": "^5.2.4",
         "vue-toastification": "^2.0.0-rc.5",
+        "vue3-apexcharts": "^1.4.1",
         "vuex": "^4.0.0"
       },
       "devDependencies": {
@@ -2315,9 +2316,9 @@
       "dev": true
     },
     "node_modules/@vue/vue-loader-v15/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -2327,9 +2328,9 @@
       }
     },
     "node_modules/@vue/vue-loader-v15/node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -2866,6 +2867,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apexcharts": {
+      "version": "3.36.3",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.36.3.tgz",
+      "integrity": "sha512-8/FXEs0ohXMff07Gv28XjhPwEJphIUdq2/wii/pcvi54Tw6z1mjrV8ydN8rlWi/ve8BAPBefJkLmRWv7UOBsLw==",
+      "peer": true,
+      "dependencies": {
+        "svg.draggable.js": "^2.2.2",
+        "svg.easing.js": "^2.0.0",
+        "svg.filter.js": "^2.0.2",
+        "svg.pathmorphing.js": "^0.1.3",
+        "svg.resize.js": "^1.4.3",
+        "svg.select.js": "^3.0.1"
       }
     },
     "node_modules/arch": {
@@ -8471,9 +8486,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -8590,9 +8605,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -11492,6 +11507,97 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg.draggable.js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+      "peer": true,
+      "dependencies": {
+        "svg.js": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.easing.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+      "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+      "peer": true,
+      "dependencies": {
+        "svg.js": ">=2.3.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.filter.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+      "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+      "peer": true,
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==",
+      "peer": true
+    },
+    "node_modules/svg.pathmorphing.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+      "peer": true,
+      "dependencies": {
+        "svg.js": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+      "peer": true,
+      "dependencies": {
+        "svg.js": "^2.6.5",
+        "svg.select.js": "^2.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.resize.js/node_modules/svg.select.js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+      "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+      "peer": true,
+      "dependencies": {
+        "svg.js": "^2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/svg.select.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+      "peer": true,
+      "dependencies": {
+        "svg.js": "^2.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -12333,9 +12439,9 @@
       "dev": true
     },
     "node_modules/vue-style-loader/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -12345,9 +12451,9 @@
       }
     },
     "node_modules/vue-style-loader/node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -12370,6 +12476,15 @@
       "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
       "peerDependencies": {
         "vue": "^3.0.2"
+      }
+    },
+    "node_modules/vue3-apexcharts": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/vue3-apexcharts/-/vue3-apexcharts-1.4.1.tgz",
+      "integrity": "sha512-96qP8JDqB9vwU7bkG5nVU+E0UGQn7yYQVqUUCLQMYWDuQyu2vE77H/UFZ1yI+hwzlSTBKT9BqnNG8JsFegB3eg==",
+      "peerDependencies": {
+        "apexcharts": "> 3.0.0",
+        "vue": "> 3.0.0"
       }
     },
     "node_modules/vuex": {
@@ -14824,18 +14939,18 @@
           "dev": true
         },
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -15266,6 +15381,20 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apexcharts": {
+      "version": "3.36.3",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.36.3.tgz",
+      "integrity": "sha512-8/FXEs0ohXMff07Gv28XjhPwEJphIUdq2/wii/pcvi54Tw6z1mjrV8ydN8rlWi/ve8BAPBefJkLmRWv7UOBsLw==",
+      "peer": true,
+      "requires": {
+        "svg.draggable.js": "^2.2.2",
+        "svg.easing.js": "^2.0.0",
+        "svg.filter.js": "^2.0.2",
+        "svg.pathmorphing.js": "^0.1.3",
+        "svg.resize.js": "^1.4.3",
+        "svg.select.js": "^3.0.1"
       }
     },
     "arch": {
@@ -19481,9 +19610,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -19571,9 +19700,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -21719,6 +21848,78 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "svg.draggable.js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
+      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
+      "peer": true,
+      "requires": {
+        "svg.js": "^2.0.1"
+      }
+    },
+    "svg.easing.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
+      "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
+      "peer": true,
+      "requires": {
+        "svg.js": ">=2.3.x"
+      }
+    },
+    "svg.filter.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
+      "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
+      "peer": true,
+      "requires": {
+        "svg.js": "^2.2.5"
+      }
+    },
+    "svg.js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
+      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==",
+      "peer": true
+    },
+    "svg.pathmorphing.js": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
+      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
+      "peer": true,
+      "requires": {
+        "svg.js": "^2.4.0"
+      }
+    },
+    "svg.resize.js": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
+      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
+      "peer": true,
+      "requires": {
+        "svg.js": "^2.6.5",
+        "svg.select.js": "^2.1.2"
+      },
+      "dependencies": {
+        "svg.select.js": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
+          "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
+          "peer": true,
+          "requires": {
+            "svg.js": "^2.2.5"
+          }
+        }
+      }
+    },
+    "svg.select.js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
+      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
+      "peer": true,
+      "requires": {
+        "svg.js": "^2.6.5"
+      }
+    },
     "svgo": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -22333,18 +22534,18 @@
           "dev": true
         },
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -22364,6 +22565,12 @@
       "version": "2.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
       "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "requires": {}
+    },
+    "vue3-apexcharts": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/vue3-apexcharts/-/vue3-apexcharts-1.4.1.tgz",
+      "integrity": "sha512-96qP8JDqB9vwU7bkG5nVU+E0UGQn7yYQVqUUCLQMYWDuQyu2vE77H/UFZ1yI+hwzlSTBKT9BqnNG8JsFegB3eg==",
       "requires": {}
     },
     "vuex": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vue-router": "^4.0.3",
     "vue-sidebar-menu": "^5.2.4",
     "vue-toastification": "^2.0.0-rc.5",
+    "vue3-apexcharts": "^1.4.1",
     "vuex": "^4.0.0"
   },
   "devDependencies": {

--- a/src/components/CourseComponents/CloneCourseModal.vue
+++ b/src/components/CourseComponents/CloneCourseModal.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { defineEmits } from "vue/dist/vue";
-import { ref } from "vue";
+import { defineProps, ref, watch } from "vue";
 import { useToast } from "vue-toastification";
 import { ICloneCourse, ICourse } from "@/ts/models/overworld-models";
-import { defineProps, watch } from "vue";
 import { postCloneCourse } from "@/ts/rest-clients/course-rest-client";
 import { validateSemester } from "@/ts/validation/validate";
 

--- a/src/components/CourseComponents/CreateCourseModal.vue
+++ b/src/components/CourseComponents/CreateCourseModal.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { defineEmits } from "vue/dist/vue";
-import { ref } from "vue";
+import { defineProps, ref, watch } from "vue";
 import { postCourse } from "@/ts/rest-clients/course-rest-client";
 import { useToast } from "vue-toastification";
 import { ICourse } from "@/ts/models/overworld-models";
-import { defineProps, watch } from "vue";
 import { validateSemester } from "@/ts/validation/validate";
 
 const props = defineProps<{

--- a/src/components/EditBookModal.vue
+++ b/src/components/EditBookModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineProps, defineEmits, ref, watch, Ref } from "vue";
+import { defineEmits, defineProps, ref, Ref, watch } from "vue";
 import { IBook } from "@/ts/models/overworld-models";
 
 const props = defineProps<{

--- a/src/components/EditMinigameModals/EditBugfinderConifgurationModal.vue
+++ b/src/components/EditMinigameModals/EditBugfinderConifgurationModal.vue
@@ -11,7 +11,6 @@ import {
   postBugfinderConfig,
 } from "@/ts/rest-clients/bugfinder-rest-client";
 import { putMinigame } from "@/ts/rest-clients/minigame-rest-client";
-import { ViewportMaxHeightProperty } from "csstype";
 import { defineEmits, defineProps, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 

--- a/src/components/EditMinigameModals/EditChickenshockConfigurationModal.vue
+++ b/src/components/EditMinigameModals/EditChickenshockConfigurationModal.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { saveAs } from "file-saver";
-import { arrayOf, defaultValue, object, string, int } from "checkeasy";
+import { arrayOf, defaultValue, int, object, string } from "checkeasy";
 import { importConfiguration } from "@/ts/import-configuration";
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineEmits, defineProps, ref, watch } from "vue";
 import {
-  IChickenshockQuestion,
   ChickenshockConfiguration,
+  IChickenshockQuestion,
 } from "@/ts/models/chickenshock-models";
 import {
   getChickenshockConfig,

--- a/src/components/EditMinigameModals/EditCrosswordpuzzleModal.vue
+++ b/src/components/EditMinigameModals/EditCrosswordpuzzleModal.vue
@@ -4,7 +4,7 @@ const compatibleVersions = ["v0.0.6"];
 import { saveAs } from "file-saver";
 import { arrayOf, object, optional, string } from "checkeasy";
 import { importConfiguration } from "@/ts/import-configuration";
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineEmits, defineProps, ref, watch } from "vue";
 import { ITask } from "@/ts/models/overworld-models";
 import {
   CrosswordpuzzleConfiguration,

--- a/src/components/EditMinigameModals/EditFinitequizConfigurationModal.vue
+++ b/src/components/EditMinigameModals/EditFinitequizConfigurationModal.vue
@@ -4,7 +4,7 @@ const compatibleVersions = ["v0.0.1"];
 import { saveAs } from "file-saver";
 import { arrayOf, object, string } from "checkeasy";
 import { importConfiguration } from "@/ts/import-configuration";
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineEmits, defineProps, ref, watch } from "vue";
 import { ITask } from "@/ts/models/overworld-models";
 import {
   FinitequizConfiguration,

--- a/src/components/EditMinigameModals/EditMinigameConfigurationModal.vue
+++ b/src/components/EditMinigameModals/EditMinigameConfigurationModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineEmits, defineProps, ref, watch } from "vue";
 import { ITask } from "@/ts/models/overworld-models";
 
 const props = defineProps<{

--- a/src/components/EditMinigameModals/EditTowercrushConfigurationModal.vue
+++ b/src/components/EditMinigameModals/EditTowercrushConfigurationModal.vue
@@ -4,11 +4,11 @@ const compatibleVersions = ["v0.0.1"];
 import { saveAs } from "file-saver";
 import { arrayOf, object, string } from "checkeasy";
 import { importConfiguration } from "@/ts/import-configuration";
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineEmits, defineProps, ref, watch } from "vue";
 import { ITask } from "@/ts/models/overworld-models";
 import {
-  TowercrushConfiguration,
   ITowercrushQuestion,
+  TowercrushConfiguration,
 } from "@/ts/models/towercrush-models";
 import { useToast } from "vue-toastification";
 import { putMinigame } from "@/ts/rest-clients/minigame-rest-client";

--- a/src/components/EditNPCModal.vue
+++ b/src/components/EditNPCModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineEmits, defineProps, ref, watch } from "vue";
 import { INPC } from "@/ts/models/overworld-models";
 
 const props = defineProps<{

--- a/src/components/EditableStringAttribute.vue
+++ b/src/components/EditableStringAttribute.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineProps, defineEmits, ref, watch, nextTick } from "vue";
+import { defineEmits, defineProps, nextTick, ref, watch } from "vue";
 
 const props = defineProps<{
   value: string | null;

--- a/src/components/MapImageModal.vue
+++ b/src/components/MapImageModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import config from "@/config";
-import { defineProps, defineEmits, ref, watch } from "vue";
+import { defineEmits, defineProps, ref, watch } from "vue";
 import { MapType } from "@/ts/models/overworld-models";
 
 const props = defineProps<{

--- a/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
+++ b/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { ApexOptions } from "apexcharts";
+import { loadTimeSpentDistributionInRangeBar } from "@/ts/statistics/finitequiz-statistics";
+import { ref, watch, Ref, defineProps } from "vue";
+
+const loadingMinigameSpecificStatistics = ref(false);
+const isEnoughDataForStatistic = ref(true);
+
+const inFocus = ref(false);
+
+watch(
+  () => props.configurationId,
+  (newValue) => {
+    loadMinigameStatistic(props.configurationId);
+  },
+  { deep: true }
+);
+const props = defineProps({
+  upClicked: Boolean,
+  downClicked: Boolean,
+  inFocus: Boolean,
+  leftClicked: Boolean,
+  rightClicked: Boolean,
+  configurationId: String,
+});
+
+watch(
+  () => props.inFocus,
+  (newBoolean) => {
+    inFocus.value = newBoolean;
+  },
+  { deep: true }
+);
+
+async function loadMinigameStatistic(configurationId: string | undefined) {
+  if (!configurationId) {
+    throw new Error(
+      "Configuration ID must be present when loading minigame specific statistics"
+    );
+  }
+  loadingMinigameSpecificStatistics.value = true;
+  const promisesToWait = [
+    loadTimeSpentDistributionInRangeBar(
+      configurationId,
+      timeSpentDistributionRangeBar.value
+    ),
+  ];
+  await Promise.all(promisesToWait);
+  loadingMinigameSpecificStatistics.value = false;
+}
+
+const timeSpentDistributionRangeBar = ref({
+  options: {
+    chart: { type: "rangeBar" },
+    title: { text: "Time spent per minigame run" },
+  } as ApexOptions,
+  series: [] as Array<{
+    data: Array<{ x: string; y: Array<number> }>;
+  }>,
+});
+
+loadMinigameStatistic(props.configurationId);
+</script>
+
+<template>
+  <b-overlay :show="loadingMinigameSpecificStatistics" rounded="sm">
+    <b-row id="minigame-specific-statistics" class="container mt-4">
+      <h2>Minigame specific statistics</h2>
+      <b-col>
+        <apexchart
+          width="600"
+          :options="timeSpentDistributionRangeBar.options"
+          :series="timeSpentDistributionRangeBar.series"
+        ></apexchart
+      ></b-col>
+    </b-row>
+  </b-overlay>
+</template>

--- a/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
+++ b/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
@@ -7,14 +7,13 @@ import {
 import { ref, watch, Ref, defineProps } from "vue";
 
 const loadingMinigameSpecificStatistics = ref(false);
-const isEnoughDataForStatistic = ref(true);
 
 const inFocus = ref(false);
 
 watch(
   () => props.configurationId,
   (newValue) => {
-    loadMinigameStatistic(props.configurationId);
+    loadMinigameStatistic(newValue);
   },
   { deep: true }
 );

--- a/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
+++ b/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { ApexOptions } from "apexcharts";
 import {
-  loadTimeSpentDistributionInRangeBar,
   loadProblematicQuestionsInBarChart,
+  loadTimeSpentDistributionInRangeBar,
 } from "@/ts/statistics/finitequiz-statistics";
-import { ref, watch, Ref, defineProps } from "vue";
+import { defineProps, Ref, ref, watch } from "vue";
 
 const loadingMinigameSpecificStatistics = ref(false);
 

--- a/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
+++ b/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ApexOptions } from "apexcharts";
-import { loadTimeSpentDistributionInRangeBar } from "@/ts/statistics/finitequiz-statistics";
+import {
+  loadTimeSpentDistributionInRangeBar,
+  loadProblematicQuestionsInBarChart,
+} from "@/ts/statistics/finitequiz-statistics";
 import { ref, watch, Ref, defineProps } from "vue";
 
 const loadingMinigameSpecificStatistics = ref(false);
@@ -44,12 +47,17 @@ async function loadMinigameStatistic(configurationId: string | undefined) {
       configurationId,
       timeSpentDistributionRangeBar.value
     ),
+    loadProblematicQuestionsInBarChart(
+      configurationId,
+      problematicQuestionsBarChart.value
+    ),
   ];
   await Promise.all(promisesToWait);
   loadingMinigameSpecificStatistics.value = false;
 }
 
 const timeSpentDistributionRangeBar = ref({
+  width: 600,
   options: {
     chart: { type: "rangeBar" },
     title: { text: "Time spent per minigame run" },
@@ -59,6 +67,20 @@ const timeSpentDistributionRangeBar = ref({
   }>,
 });
 
+const problematicQuestionsBarChart = ref({
+  width: 600,
+  options: {
+    chart: { type: "bar" },
+    title: { text: "Problematic questions per minigame run" },
+  } as ApexOptions,
+  series: [] as Array<{ name: string; data: Array<number> }>,
+});
+
+const statistics = [
+  timeSpentDistributionRangeBar,
+  problematicQuestionsBarChart,
+] as Array<Ref<{ width: number; options: ApexOptions; series: Array<any> }>>;
+
 loadMinigameStatistic(props.configurationId);
 </script>
 
@@ -66,11 +88,14 @@ loadMinigameStatistic(props.configurationId);
   <b-overlay :show="loadingMinigameSpecificStatistics" rounded="sm">
     <b-row id="minigame-specific-statistics" class="container mt-4">
       <h2>Minigame specific statistics</h2>
-      <b-col>
+      <b-col
+        v-for="statistic of statistics"
+        :key="statistic.value.options.title"
+      >
         <apexchart
-          width="600"
-          :options="timeSpentDistributionRangeBar.options"
-          :series="timeSpentDistributionRangeBar.series"
+          :width="statistic.value.width"
+          :options="statistic.value.options"
+          :series="statistic.value.series"
         ></apexchart
       ></b-col>
     </b-row>

--- a/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
+++ b/src/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue
@@ -37,6 +37,9 @@ watch(
 
 async function loadMinigameStatistic(configurationId: string | undefined) {
   if (!configurationId) {
+    statistics.forEach(
+      (statistic) => (statistic.value.enoughDataToShow = false)
+    );
     throw new Error(
       "Configuration ID must be present when loading minigame specific statistics"
     );
@@ -57,6 +60,7 @@ async function loadMinigameStatistic(configurationId: string | undefined) {
 }
 
 const timeSpentDistributionRangeBar = ref({
+  enoughDataToShow: true,
   width: 600,
   options: {
     chart: { type: "rangeBar" },
@@ -68,6 +72,7 @@ const timeSpentDistributionRangeBar = ref({
 });
 
 const problematicQuestionsBarChart = ref({
+  enoughDataToShow: true,
   width: 600,
   options: {
     chart: { type: "bar" },
@@ -79,7 +84,14 @@ const problematicQuestionsBarChart = ref({
 const statistics = [
   timeSpentDistributionRangeBar,
   problematicQuestionsBarChart,
-] as Array<Ref<{ width: number; options: ApexOptions; series: Array<any> }>>;
+] as Array<
+  Ref<{
+    enoughDataToShow: boolean;
+    width: number;
+    options: ApexOptions;
+    series: Array<any>;
+  }>
+>;
 
 loadMinigameStatistic(props.configurationId);
 </script>
@@ -92,12 +104,17 @@ loadMinigameStatistic(props.configurationId);
         v-for="statistic of statistics"
         :key="statistic.value.options.title"
       >
-        <apexchart
-          :width="statistic.value.width"
-          :options="statistic.value.options"
-          :series="statistic.value.series"
-        ></apexchart
-      ></b-col>
+        <b-overlay :show="!statistic.value.enoughDataToShow" rounded="sm">
+          <apexchart
+            :width="statistic.value.width"
+            :options="statistic.value.options"
+            :series="statistic.value.series"
+          ></apexchart>
+          <template #overlay>
+            <h6>Statistic has not enough data to show.</h6>
+          </template>
+        </b-overlay></b-col
+      >
     </b-row>
   </b-overlay>
 </template>

--- a/src/components/Sidebar/CourseSidebarMenu.vue
+++ b/src/components/Sidebar/CourseSidebarMenu.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { defineProps, nextTick, ref, watch } from "vue";
+import { computed, defineProps, nextTick, ref, watch } from "vue";
 import "vue-sidebar-menu/dist/vue-sidebar-menu.css";
 import { ICourse, IDungeon, IWorld } from "@/ts/models/overworld-models";
-
-import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { getCourse } from "@/ts/rest-clients/course-rest-client";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,8 +12,11 @@ import "vue-sidebar-menu/dist/vue-sidebar-menu.css";
 import Toast from "vue-toastification";
 import "vue-toastification/dist/index.css";
 
+import VueApexCharts from "vue3-apexcharts";
+
 const app = createApp(App);
 app.use(BootstrapVue3);
 app.use(Toast);
 app.use(VueSidebarMenu);
+app.use(VueApexCharts);
 app.use(router).mount("#app");

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import WorldView from "@/views/WorldView.vue";
 import CoursesView from "@/views/CoursesView.vue";
 import CourseView from "@/views/CourseView.vue";
 import MinigameTasksView from "@/views/MinigameTasksView.vue";
+import MinigameTaskStatisticView from "@/views/MinigameTaskStatisticView.vue";
 import NPCView from "@/views/NPCsView.vue";
 import BooksView from "@/views/BooksView.vue";
 
@@ -32,6 +33,16 @@ const routes: Array<RouteRecordRaw> = [
     path: "/courses/:courseId/worlds/:worldIndex/dungeons/:dungeonIndex/minigames",
     name: "dungeon-minigames",
     component: MinigameTasksView,
+  },
+  {
+    path: "/courses/:courseId/worlds/:worldIndex/minigames/:minigameIndex/statistics",
+    name: "world-minigame-statistics",
+    component: MinigameTaskStatisticView,
+  },
+  {
+    path: "/courses/:courseId/worlds/:worldIndex/dungeons/:dungeonIndex/minigames/:minigameIndex/statistics",
+    name: "dungeon-minigame-statistics",
+    component: MinigameTaskStatisticView,
   },
   {
     path: "/courses/:courseId/worlds/:worldIndex/npcs",

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 declare module '*.vue' {
-  import type { DefineComponent } from 'vue'
+  import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>
   export default component
 }

--- a/src/ts/rest-clients/finitequiz-minigame-statistics-rest-client.ts
+++ b/src/ts/rest-clients/finitequiz-minigame-statistics-rest-client.ts
@@ -9,3 +9,11 @@ export async function getTimeSpentDistributionStatistic(
     `${config.finitequizApiUrl}/statistics/${configurationId}/time-spent`
   );
 }
+
+export async function getProblematicQuestionsStatistic(
+  configurationId: string
+): Promise<AxiosResponse> {
+  return axios.get(
+    `${config.finitequizApiUrl}/statistics/${configurationId}/problematic-questions`
+  );
+}

--- a/src/ts/rest-clients/finitequiz-minigame-statistics-rest-client.ts
+++ b/src/ts/rest-clients/finitequiz-minigame-statistics-rest-client.ts
@@ -1,0 +1,11 @@
+import axios, { AxiosResponse } from "axios";
+
+import config from "@/config";
+
+export async function getTimeSpentDistributionStatistic(
+  configurationId: string
+): Promise<AxiosResponse> {
+  return axios.get(
+    `${config.finitequizApiUrl}/statistics/${configurationId}/time-spent`
+  );
+}

--- a/src/ts/rest-clients/minigame-rest-client.ts
+++ b/src/ts/rest-clients/minigame-rest-client.ts
@@ -19,6 +19,23 @@ export async function getMinigames(
   }
 }
 
+export async function getMinigame(
+  courseId: number,
+  worldIndex: number,
+  dungeonIndex: number | undefined,
+  minigameIndex: number
+): Promise<AxiosResponse> {
+  if (dungeonIndex != undefined) {
+    return axios.get(
+      `${config.overworldApiUrl}/courses/${courseId}/worlds/${worldIndex}/dungeons/${dungeonIndex}/minigame-tasks/${minigameIndex}`
+    );
+  } else {
+    return axios.get(
+      `${config.overworldApiUrl}/courses/${courseId}/worlds/${worldIndex}/minigame-tasks/${minigameIndex}`
+    );
+  }
+}
+
 export async function putMinigame(
   courseId: number,
   worldIndex: number,

--- a/src/ts/rest-clients/minigame-statistics-rest-client.ts
+++ b/src/ts/rest-clients/minigame-statistics-rest-client.ts
@@ -1,0 +1,20 @@
+import axios, { AxiosResponse } from "axios";
+
+import config from "@/config";
+
+export async function getSuccessRateStatistic(
+  courseId: number,
+  worldIndex: number,
+  dungeonIndex: number | undefined,
+  minigameIndex: number
+): Promise<AxiosResponse> {
+  if (dungeonIndex != undefined) {
+    return axios.get(
+      `${config.overworldApiUrl}/courses/${courseId}/worlds/${worldIndex}/dungeons/${dungeonIndex}/minigame-tasks/${minigameIndex}/statistics/success-rate`
+    );
+  } else {
+    return axios.get(
+      `${config.overworldApiUrl}/courses/${courseId}/worlds/${worldIndex}/minigame-tasks/${minigameIndex}/statistics/success-rate`
+    );
+  }
+}

--- a/src/ts/rest-clients/minigame-statistics-rest-client.ts
+++ b/src/ts/rest-clients/minigame-statistics-rest-client.ts
@@ -18,3 +18,20 @@ export async function getSuccessRateStatistic(
     );
   }
 }
+
+export async function getHighscoreDistributionStatistic(
+  courseId: string,
+  worldIndex: number,
+  dungeonIndex: number | undefined,
+  minigameIndex: number
+): Promise<AxiosResponse> {
+  if (dungeonIndex != undefined) {
+    return axios.get(
+      `${config.overworldApiUrl}/courses/${courseId}/worlds/${worldIndex}/dungeons/${dungeonIndex}/minigame-tasks/${minigameIndex}/statistics/highscore-distribution`
+    );
+  } else {
+    return axios.get(
+      `${config.overworldApiUrl}/courses/${courseId}/worlds/${worldIndex}/minigame-tasks/${minigameIndex}/statistics/highscore-distribution`
+    );
+  }
+}

--- a/src/ts/rest-clients/minigame-statistics-rest-client.ts
+++ b/src/ts/rest-clients/minigame-statistics-rest-client.ts
@@ -3,7 +3,7 @@ import axios, { AxiosResponse } from "axios";
 import config from "@/config";
 
 export async function getSuccessRateStatistic(
-  courseId: number,
+  courseId: string,
   worldIndex: number,
   dungeonIndex: number | undefined,
   minigameIndex: number

--- a/src/ts/statistics/finitequiz-statistics.ts
+++ b/src/ts/statistics/finitequiz-statistics.ts
@@ -9,10 +9,7 @@ const redColor = "#FF0000";
 /**
  * Loads the time spent distribution of a minigame task into the present range bar chart.
  *
- * @param courseId the id of the course the minigame task is part off
- * @param worldIndex the index of the world
- * @param dungeonIndex the index of the dungeon (optional, undefined if the area is a world)
- * @param minigameIndex the index of the minigame the statistic should be
+ * @param configurationId the id of the configuration
  * @param rangeBar the range bar to update with highscore distribution
  * @returns a promise that resolves after the chart has been updated
  */
@@ -32,7 +29,6 @@ export async function loadTimeSpentDistributionInRangeBar(
         const toPercentage: number = timeSpentDistribution.toPercentage;
         const fromTime: number = timeSpentDistribution.fromTime;
         const toTime: number = timeSpentDistribution.toTime;
-        const count: number = timeSpentDistribution.count;
         data.push({
           x: `${fromPercentage}% to ${toPercentage}% of game runs`,
           y: [fromTime, toTime],
@@ -69,10 +65,7 @@ export async function loadTimeSpentDistributionInRangeBar(
 /**
  * Loads the time spent distribution of a minigame task into the present range bar chart.
  *
- * @param courseId the id of the course the minigame task is part off
- * @param worldIndex the index of the world
- * @param dungeonIndex the index of the dungeon (optional, undefined if the area is a world)
- * @param minigameIndex the index of the minigame the statistic should be
+ * @param configurationId the id of the configuration
  * @param rangeBar the range bar to update with highscore distribution
  * @returns a promise that resolves after the chart has been updated
  */
@@ -83,7 +76,6 @@ export async function loadProblematicQuestionsInBarChart(
   return getProblematicQuestionsStatistic(configurationId).then(
     async (response) => {
       const result: Array<any> = response.data;
-      const data = [] as Array<{ x: string; y: Array<number> }>;
       const series = [
         { name: "Correct answers", data: [] },
         { name: "Wrong answers", data: [] },
@@ -93,7 +85,6 @@ export async function loadProblematicQuestionsInBarChart(
       }>;
       const categories = [] as Array<string>;
       for (const problematicQuestion of result) {
-        const attempts: number = problematicQuestion.attempts;
         const correctAnswers: number = problematicQuestion.correctAnswers;
         const wrongAnswers: number = problematicQuestion.wrongAnswers;
         const question: { text: string } = problematicQuestion.question;

--- a/src/ts/statistics/finitequiz-statistics.ts
+++ b/src/ts/statistics/finitequiz-statistics.ts
@@ -1,4 +1,10 @@
-import { getTimeSpentDistributionStatistic } from "@/ts/rest-clients/finitequiz-minigame-statistics-rest-client";
+import {
+  getTimeSpentDistributionStatistic,
+  getProblematicQuestionsStatistic,
+} from "@/ts/rest-clients/finitequiz-minigame-statistics-rest-client";
+
+const greenColor = "#00FF00";
+const redColor = "#FF0000";
 
 /**
  * Loads the time spent distribution of a minigame task into the present range bar chart.
@@ -28,7 +34,7 @@ export async function loadTimeSpentDistributionInRangeBar(
         const toTime: number = timeSpentDistribution.toTime;
         const count: number = timeSpentDistribution.count;
         data.push({
-          x: `${fromPercentage}% to ${toPercentage}% has this time`,
+          x: `${fromPercentage}% to ${toPercentage}% of game runs`,
           y: [fromTime, toTime],
         });
       }
@@ -40,6 +46,87 @@ export async function loadTimeSpentDistributionInRangeBar(
             labels: {
               formatter: (val: any) => {
                 return val + " seconds";
+              },
+            },
+            title: {
+              text: "Time in seconds",
+            },
+          },
+        },
+      };
+    }
+  );
+}
+
+/**
+ * Loads the time spent distribution of a minigame task into the present range bar chart.
+ *
+ * @param courseId the id of the course the minigame task is part off
+ * @param worldIndex the index of the world
+ * @param dungeonIndex the index of the dungeon (optional, undefined if the area is a world)
+ * @param minigameIndex the index of the minigame the statistic should be
+ * @param rangeBar the range bar to update with highscore distribution
+ * @returns a promise that resolves after the chart has been updated
+ */
+export async function loadProblematicQuestionsInBarChart(
+  configurationId: string,
+  barChart: any
+): Promise<any> {
+  return getProblematicQuestionsStatistic(configurationId).then(
+    async (response) => {
+      const result: Array<any> = response.data;
+      const data = [] as Array<{ x: string; y: Array<number> }>;
+      const series = [
+        { name: "Correct answers", data: [] },
+        { name: "Wrong answers", data: [] },
+      ] as Array<{
+        name: string;
+        data: Array<number>;
+      }>;
+      const categories = [] as Array<string>;
+      for (const problematicQuestion of result) {
+        const attempts: number = problematicQuestion.attempts;
+        const correctAnswers: number = problematicQuestion.correctAnswers;
+        const wrongAnswers: number = problematicQuestion.wrongAnswers;
+        const question: { text: string } = problematicQuestion.question;
+        categories.push(question.text);
+        series[0].data.push(correctAnswers);
+        series[1].data.push(wrongAnswers);
+      }
+      barChart.series = series;
+      barChart.options = {
+        ...barChart.options,
+        ...{
+          xaxis: {
+            categories: categories,
+            labels: {
+              formatter: (val: any) => {
+                return val + " tries";
+              },
+            },
+            title: "Tries",
+          },
+          yaxis: {
+            title: {
+              text: "Question",
+            },
+          },
+          chart: {
+            stacked: true,
+          },
+          colors: [greenColor, redColor],
+          plotOptions: {
+            bar: {
+              horizontal: true,
+              dataLabels: {
+                total: {
+                  enabled: true,
+                  offsetX: 0,
+                  style: {
+                    fontSize: "13px",
+                    fontWeight: 900,
+                  },
+                },
               },
             },
           },

--- a/src/ts/statistics/finitequiz-statistics.ts
+++ b/src/ts/statistics/finitequiz-statistics.ts
@@ -38,6 +38,14 @@ export async function loadTimeSpentDistributionInRangeBar(
           y: [fromTime, toTime],
         });
       }
+
+      rangeBar.enoughDataToShow = true;
+      data.forEach((dataPoint) => {
+        if (dataPoint.y[0] == dataPoint.y[1]) {
+          rangeBar.enoughDataToShow = false;
+        }
+      });
+
       rangeBar.series = series;
       rangeBar.options = {
         ...rangeBar.options,
@@ -93,6 +101,9 @@ export async function loadProblematicQuestionsInBarChart(
         series[0].data.push(correctAnswers);
         series[1].data.push(wrongAnswers);
       }
+
+      barChart.enoughDataToShow = series.length > 0;
+
       barChart.series = series;
       barChart.options = {
         ...barChart.options,

--- a/src/ts/statistics/finitequiz-statistics.ts
+++ b/src/ts/statistics/finitequiz-statistics.ts
@@ -1,0 +1,50 @@
+import { getTimeSpentDistributionStatistic } from "@/ts/rest-clients/finitequiz-minigame-statistics-rest-client";
+
+/**
+ * Loads the time spent distribution of a minigame task into the present range bar chart.
+ *
+ * @param courseId the id of the course the minigame task is part off
+ * @param worldIndex the index of the world
+ * @param dungeonIndex the index of the dungeon (optional, undefined if the area is a world)
+ * @param minigameIndex the index of the minigame the statistic should be
+ * @param rangeBar the range bar to update with highscore distribution
+ * @returns a promise that resolves after the chart has been updated
+ */
+export async function loadTimeSpentDistributionInRangeBar(
+  configurationId: string,
+  rangeBar: any
+): Promise<any> {
+  return getTimeSpentDistributionStatistic(configurationId).then(
+    async (response) => {
+      const result: Array<any> = response.data;
+      const data = [] as Array<{ x: string; y: Array<number> }>;
+      const series = [{ data: data }] as Array<{
+        data: Array<{ x: string; y: Array<number> }>;
+      }>;
+      for (const timeSpentDistribution of result) {
+        const fromPercentage: number = timeSpentDistribution.fromPercentage;
+        const toPercentage: number = timeSpentDistribution.toPercentage;
+        const fromTime: number = timeSpentDistribution.fromTime;
+        const toTime: number = timeSpentDistribution.toTime;
+        const count: number = timeSpentDistribution.count;
+        data.push({
+          x: `${fromPercentage}% to ${toPercentage}% has this time`,
+          y: [fromTime, toTime],
+        });
+      }
+      rangeBar.series = series;
+      rangeBar.options = {
+        ...rangeBar.options,
+        ...{
+          yaxis: {
+            labels: {
+              formatter: (val: any) => {
+                return val + " seconds";
+              },
+            },
+          },
+        },
+      };
+    }
+  );
+}

--- a/src/ts/statistics/finitequiz-statistics.ts
+++ b/src/ts/statistics/finitequiz-statistics.ts
@@ -1,6 +1,6 @@
 import {
-  getTimeSpentDistributionStatistic,
   getProblematicQuestionsStatistic,
+  getTimeSpentDistributionStatistic,
 } from "@/ts/rest-clients/finitequiz-minigame-statistics-rest-client";
 
 const greenColor = "#00FF00";

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -1,4 +1,7 @@
-import { getSuccessRateStatistic } from "@/ts/rest-clients/minigame-statistics-rest-client";
+import {
+  getSuccessRateStatistic,
+  getHighscoreDistributionStatistic,
+} from "@/ts/rest-clients/minigame-statistics-rest-client";
 
 /**
  * Loads the success rate of a minigame task into the present pie chart.
@@ -58,12 +61,57 @@ export async function loadAverageSuccessInPieChart(
     pieChart.options = {
       ...pieChart.options,
       ...{
-        title: { text: "Average Success" },
         labels: labels,
         colors: colors,
       },
     };
     await wait(1000);
+  });
+}
+
+/**
+ * Loads the highscore distribution of a minigame task into the present bar chart.
+ *
+ * @param courseId the id of the course the minigame task is part off
+ * @param worldIndex the index of the world
+ * @param dungeonIndex the index of the dungeon (optional, undefined if the area is a world)
+ * @param minigameIndex the index of the minigame the statistic should be
+ * @param rangeBar the range bar to update with highscore distribution
+ * @returns a promise that resolves after the chart has been updated
+ */
+export async function loadHighscoreDistributionInRangeBar(
+  courseId: string,
+  worldIndex: number,
+  dungeonIndex: number | undefined,
+  minigameIndex: number,
+  rangeBar: any
+): Promise<any> {
+  return getHighscoreDistributionStatistic(
+    courseId,
+    worldIndex,
+    dungeonIndex,
+    minigameIndex
+  ).then(async (response) => {
+    const result: Array<any> = response.data;
+    const data = [] as Array<{ x: string; y: Array<number> }>;
+    const series = [{ data: data }] as Array<{
+      data: Array<{ x: string; y: Array<number> }>;
+    }>;
+    for (const highscoreDistribution of result) {
+      const fromPercentage: number = highscoreDistribution.fromPercentage;
+      const toPercentage: number = highscoreDistribution.toPercentage;
+      const fromScore: number = highscoreDistribution.fromScore;
+      const toScore: number = highscoreDistribution.toScore;
+      const count: number = highscoreDistribution.count;
+      data.push({
+        x: `${fromPercentage}% to ${toPercentage}% has this score`,
+        y: [fromScore, toScore],
+      });
+    }
+    console.log(result);
+    console.log(data);
+
+    rangeBar.series = series;
   });
 }
 

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -1,0 +1,80 @@
+import { getSuccessRateStatistic } from "@/ts/rest-clients/minigame-statistics-rest-client";
+
+/**
+ * Loads the success rate of a minigame task into the present pie chart.
+ *
+ * @param courseId the id of the course the minigame task is part off
+ * @param worldIndex the index of the world
+ * @param dungeonIndex the index of the dungeon (optional, undefined if the area is a world)
+ * @param minigameIndex the index of the minigame the statistic should be
+ * @param pieChart the pie chart to update with success rate data
+ * @returns a promise that resolves after the chart has been updated
+ */
+export async function loadAverageSuccessInPieChart(
+  courseId: string,
+  worldIndex: number,
+  dungeonIndex: number | undefined,
+  minigameIndex: number,
+  pieChart: any
+): Promise<any> {
+  return getSuccessRateStatistic(
+    courseId,
+    worldIndex,
+    dungeonIndex,
+    minigameIndex
+  ).then(async (response) => {
+    const result = response.data;
+    const sumSuccessAt = 5;
+    let successHigherThanSuccessAt = 0;
+    let fails = 0;
+    let series = [] as Array<number>;
+    let labels = [] as Array<string>;
+    const greenColor = "#00FF00";
+    const redColor = "#FF0000";
+    let colors = [] as Array<string>;
+    for (const key in result.successRateDistribution) {
+      if (+key < sumSuccessAt) {
+        series = [...series, result.successRateDistribution[key]];
+        labels = [...labels, `Beim ${key}. Versuch bestanden`];
+        // TODO: make color darker on every iteration
+        colors = [...colors, greenColor];
+      } else {
+        successHigherThanSuccessAt += result.successRateDistribution[key];
+      }
+    }
+    if (successHigherThanSuccessAt > 0) {
+      series = [...series, successHigherThanSuccessAt];
+      labels = [...labels, `Bei ${sumSuccessAt}+. Versuch bestanden`];
+      colors = [...colors, greenColor];
+    }
+    for (const key in result.failureRateDistribution) {
+      fails += result.failureRateDistribution[key];
+    }
+    series = [...series, fails];
+    labels = [...labels, `Nicht bestanden`];
+    colors = [...colors, redColor];
+
+    pieChart.series = series;
+    pieChart.options = {
+      ...pieChart.options,
+      ...{
+        title: { text: "Average Success" },
+        labels: labels,
+        colors: colors,
+      },
+    };
+    await wait(1000);
+  });
+}
+
+/**
+ * Just a test function to make a promise take longer to test loading function
+ *
+ * @param ms the amount if milliseconds to wait
+ * @returns waiting
+ */
+function wait(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -1,6 +1,6 @@
 import {
-  getSuccessRateStatistic,
   getHighscoreDistributionStatistic,
+  getSuccessRateStatistic,
 } from "@/ts/rest-clients/minigame-statistics-rest-client";
 
 const greenColor = "#00FF00";

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -3,6 +3,9 @@ import {
   getHighscoreDistributionStatistic,
 } from "@/ts/rest-clients/minigame-statistics-rest-client";
 
+const greenColor = "#00FF00";
+const redColor = "#FF0000";
+
 /**
  * Loads the success rate of a minigame task into the present pie chart.
  *
@@ -32,8 +35,6 @@ export async function loadAverageSuccessInPieChart(
     let fails = 0;
     let series = [] as Array<number>;
     let labels = [] as Array<string>;
-    const greenColor = "#00FF00";
-    const redColor = "#FF0000";
     let colors = [] as Array<string>;
     for (const key in result.successRateDistribution) {
       if (+key < sumSuccessAt) {
@@ -65,7 +66,6 @@ export async function loadAverageSuccessInPieChart(
         colors: colors,
       },
     };
-    await wait(1000);
   });
 }
 
@@ -104,7 +104,7 @@ export async function loadHighscoreDistributionInRangeBar(
       const toScore: number = highscoreDistribution.toScore;
       const count: number = highscoreDistribution.count;
       data.push({
-        x: `${fromPercentage}% to ${toPercentage}% has this score`,
+        x: `${fromPercentage}% to ${toPercentage}% of players`,
         y: [fromScore, toScore],
       });
     }
@@ -112,6 +112,16 @@ export async function loadHighscoreDistributionInRangeBar(
     console.log(data);
 
     rangeBar.series = series;
+    rangeBar.options = {
+      ...rangeBar.options,
+      ...{
+        yaxis: {
+          title: {
+            text: "Score",
+          },
+        },
+      },
+    };
   });
 }
 

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -58,6 +58,12 @@ export async function loadAverageSuccessInPieChart(
     labels = [...labels, `Nicht bestanden`];
     colors = [...colors, redColor];
 
+    if (series.reduce((x, y) => x + y) <= 0) {
+      pieChart.enoughDataToShow = false;
+    } else {
+      pieChart.enoughDataToShow = true;
+    }
+
     pieChart.series = series;
     pieChart.options = {
       ...pieChart.options,
@@ -68,7 +74,6 @@ export async function loadAverageSuccessInPieChart(
     };
   });
 }
-
 /**
  * Loads the highscore distribution of a minigame task into the present bar chart.
  *
@@ -111,6 +116,13 @@ export async function loadHighscoreDistributionInRangeBar(
     console.log(result);
     console.log(data);
 
+    rangeBar.enoughDataToShow = true;
+    data.forEach((dataPoint) => {
+      if (dataPoint.y[0] == dataPoint.y[1]) {
+        rangeBar.enoughDataToShow = false;
+      }
+    });
+
     rangeBar.series = series;
     rangeBar.options = {
       ...rangeBar.options,
@@ -122,17 +134,5 @@ export async function loadHighscoreDistributionInRangeBar(
         },
       },
     };
-  });
-}
-
-/**
- * Just a test function to make a promise take longer to test loading function
- *
- * @param ms the amount if milliseconds to wait
- * @returns waiting
- */
-function wait(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
   });
 }

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -58,11 +58,7 @@ export async function loadAverageSuccessInPieChart(
     labels = [...labels, `Nicht bestanden`];
     colors = [...colors, redColor];
 
-    if (series.reduce((x, y) => x + y) <= 0) {
-      pieChart.enoughDataToShow = false;
-    } else {
-      pieChart.enoughDataToShow = true;
-    }
+    pieChart.enoughDataToShow = series.reduce((x, y) => x + y) > 0;
 
     pieChart.series = series;
     pieChart.options = {
@@ -107,7 +103,6 @@ export async function loadHighscoreDistributionInRangeBar(
       const toPercentage: number = highscoreDistribution.toPercentage;
       const fromScore: number = highscoreDistribution.fromScore;
       const toScore: number = highscoreDistribution.toScore;
-      const count: number = highscoreDistribution.count;
       data.push({
         x: `${fromPercentage}% to ${toPercentage}% of players`,
         y: [fromScore, toScore],

--- a/src/views/CourseView.vue
+++ b/src/views/CourseView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { defineEmits, nextTick, Ref, ref, watch } from "vue";
 import {
+  deleteCourse,
   getCourse,
   putCourse,
-  deleteCourse,
 } from "@/ts/rest-clients/course-rest-client";
 import { useRoute, useRouter } from "vue-router";
 import { useToast } from "vue-toastification";

--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -6,7 +6,7 @@ import {
   loadAverageSuccessInPieChart,
   loadHighscoreDistributionInRangeBar,
 } from "@/ts/statistics/overworld-statistics";
-import { ref, watch, Ref } from "vue";
+import { ref, Ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useToast } from "vue-toastification";
 import router from "@/router";

--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ApexOptions } from "apexcharts";
-import { ITask, Minigame, MapType } from "@/ts/models/overworld-models";
+import { ITask, Minigame } from "@/ts/models/overworld-models";
 import { getMinigame } from "@/ts/rest-clients/minigame-rest-client";
-import { loadAverageSuccessInPieChart } from "@/ts/statistics/overworld-statistics";
-import { defineEmits, ref, watch, Ref } from "vue";
+import {
+  loadAverageSuccessInPieChart,
+  loadHighscoreDistributionInRangeBar,
+} from "@/ts/statistics/overworld-statistics";
+import { ref, watch, Ref } from "vue";
 import { useRoute } from "vue-router";
 import { useToast } from "vue-toastification";
 import router from "@/router";
@@ -13,6 +16,7 @@ const route = useRoute();
 const loading = ref(false);
 const loadingGeneralStatistics = ref(false);
 const loadingMinigameSpecificStatistics = ref(false);
+const isEnoughDataForStatistic = ref(true);
 
 const courseId = ref(route.params.courseId as string);
 const worldIndex = ref(route.params.worldIndex as string);
@@ -91,6 +95,13 @@ async function loadMinigameStatistic(
           minigameIndex,
           successRatePieChart.value
         ),
+        loadHighscoreDistributionInRangeBar(
+          courseId,
+          worldIndex,
+          dungeonIndex,
+          minigameIndex,
+          highscoreDistributionRangeBar.value
+        ),
       ];
       await Promise.all(promisessToWait);
     })
@@ -119,6 +130,15 @@ const successRatePieChart = ref({
   } as ApexOptions,
   series: [] as Array<number>,
 });
+const highscoreDistributionRangeBar = ref({
+  options: {
+    chart: { type: "rangeBar" },
+    title: { text: "Highscore Distribution" },
+  } as ApexOptions,
+  series: [] as Array<{
+    data: Array<{ x: string; y: Array<number> }>;
+  }>,
+});
 </script>
 
 <template>
@@ -136,14 +156,23 @@ const successRatePieChart = ref({
         Here, you can see the statistic if the current miningame.</b-alert
       >
       <b-overlay :show="loadingGeneralStatistics" rounded="sm">
-        <div id="general-statistics" class="container mt-4">
+        <b-row id="general-statistics" class="container mt-4">
           <h2>General minigame statistics</h2>
-          <apexchart
-            width="600"
-            :options="successRatePieChart.options"
-            :series="successRatePieChart.series"
-          ></apexchart>
-        </div>
+          <b-col>
+            <apexchart
+              width="600"
+              :options="successRatePieChart.options"
+              :series="successRatePieChart.series"
+            ></apexchart
+          ></b-col>
+          <b-col>
+            <apexchart
+              width="600"
+              :options="highscoreDistributionRangeBar.options"
+              :series="highscoreDistributionRangeBar.series"
+            ></apexchart>
+          </b-col>
+        </b-row>
       </b-overlay>
       <b-overlay :show="loadingMinigameSpecificStatistics" rounded="sm">
         <div id="minigame-specific-statistics" class="container mt-4">

--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -11,11 +11,12 @@ import { useRoute } from "vue-router";
 import { useToast } from "vue-toastification";
 import router from "@/router";
 
+import FiniteQuizStatisticBox from "@/components/MinigameStatisticComponents/FiniteQuizStatisticBox.vue";
+
 const toast = useToast();
 const route = useRoute();
 const loading = ref(false);
 const loadingGeneralStatistics = ref(false);
-const loadingMinigameSpecificStatistics = ref(false);
 const isEnoughDataForStatistic = ref(true);
 
 const courseId = ref(route.params.courseId as string);
@@ -87,7 +88,7 @@ async function loadMinigameStatistic(
     .then(async (response) => {
       const result: ITask = response.data;
       minigame.value = result;
-      const promisessToWait = [
+      const promisesToWait = [
         loadAverageSuccessInPieChart(
           courseId,
           worldIndex,
@@ -103,7 +104,7 @@ async function loadMinigameStatistic(
           highscoreDistributionRangeBar.value
         ),
       ];
-      await Promise.all(promisessToWait);
+      await Promise.all(promisesToWait);
     })
     .catch((error) => {
       console.log(error);
@@ -115,13 +116,6 @@ async function loadMinigameStatistic(
 function goBack() {
   router.go(-1);
 }
-
-loadMinigameStatistic(
-  courseId.value,
-  worldIndex.value,
-  dungeonIndex.value,
-  minigameIndex.value
-);
 
 const successRatePieChart = ref({
   options: {
@@ -139,6 +133,13 @@ const highscoreDistributionRangeBar = ref({
     data: Array<{ x: string; y: Array<number> }>;
   }>,
 });
+
+loadMinigameStatistic(
+  courseId.value,
+  worldIndex.value,
+  dungeonIndex.value,
+  minigameIndex.value
+);
 </script>
 
 <template>
@@ -174,20 +175,14 @@ const highscoreDistributionRangeBar = ref({
           </b-col>
         </b-row>
       </b-overlay>
-      <b-overlay :show="loadingMinigameSpecificStatistics" rounded="sm">
-        <div id="minigame-specific-statistics" class="container mt-4">
-          <h2>Minigame specific statistics</h2>
-          <b-alert show dismissible>
-            Just the same statistic till we display minigame specific
-            statistics...</b-alert
-          >
-          <apexchart
-            width="600"
-            :options="successRatePieChart.options"
-            :series="successRatePieChart.series"
-          ></apexchart>
-        </div>
-      </b-overlay>
+      <FiniteQuizStatisticBox
+        v-if="minigame?.game == Minigame.FINITEQUIZ"
+        :configuration-id="minigame.configurationId"
+      />
+      <b-alert v-else variant="warning" show dismissible>
+        Minigame specific statistics not included yet for this
+        minigame.</b-alert
+      >
       <b-button @click="goBack">Back</b-button>
     </div>
   </b-overlay>

--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -17,7 +17,6 @@ const toast = useToast();
 const route = useRoute();
 const loading = ref(false);
 const loadingGeneralStatistics = ref(false);
-const isEnoughDataForStatistic = ref(true);
 
 const courseId = ref(route.params.courseId as string);
 const worldIndex = ref(route.params.worldIndex as string);
@@ -86,8 +85,7 @@ async function loadMinigameStatistic(
   }
   getMinigame(courseId, worldIndex, dungeonIndex, minigameIndex)
     .then(async (response) => {
-      const result: ITask = response.data;
-      minigame.value = result;
+      minigame.value = response.data;
       const promisesToWait = [
         loadAverageSuccessInPieChart(
           courseId,
@@ -170,7 +168,7 @@ loadMinigameStatistic(
         {{ worldIndex }}, Dungeon {{ dungeonIndex }}
       </h1>
       <b-alert show dismissible>
-        Here, you can see the statistic if the current miningame.</b-alert
+        Here, you can see the statistic of the current miningame.</b-alert
       >
       <b-button @click="goBack">Back</b-button>
       <b-overlay :show="loadingGeneralStatistics" rounded="sm">

--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { ApexOptions } from "apexcharts";
+import { ITask, Minigame, MapType } from "@/ts/models/overworld-models";
+import { getMinigame } from "@/ts/rest-clients/minigame-rest-client";
+import { getSuccessRateStatistic } from "@/ts/rest-clients/minigame-statistics-rest-client";
+import { defineEmits, ref, watch, Ref } from "vue";
+import { useRoute } from "vue-router";
+import { useToast } from "vue-toastification";
+import router from "@/router";
+
+const toast = useToast();
+const route = useRoute();
+const loading = ref(false);
+const courseId = ref(route.params.courseId as string);
+const worldIndex = ref(route.params.worldIndex as string);
+const dungeonIndex = ref(route.params.dungeonIndex as string);
+const minigameIndex = ref(route.params.minigameIndex as string);
+
+const inFocus = ref(false);
+
+watch(
+  () => [
+    route.params.courseId,
+    route.params.worldIndex,
+    route.params.dungeonIndex,
+    route.params.minigameIndex,
+  ],
+  (newVal) => {
+    courseId.value = newVal[0] as string;
+    worldIndex.value = newVal[1] as string;
+    dungeonIndex.value = newVal[2] as string;
+    minigameIndex.value = newVal[3] as string;
+
+    loadMinigameStatistic(
+      courseId.value,
+      worldIndex.value,
+      dungeonIndex.value,
+      minigameIndex.value
+    );
+  },
+  { deep: true }
+);
+const props = defineProps({
+  upClicked: Boolean,
+  downClicked: Boolean,
+  inFocus: Boolean,
+  leftClicked: Boolean,
+  rightClicked: Boolean,
+});
+
+watch(
+  () => props.inFocus,
+  (newBoolean) => {
+    inFocus.value = newBoolean;
+  },
+  { deep: true }
+);
+
+const minigame = ref() as Ref<ITask>;
+
+async function loadMinigameStatistic(
+  courseId: any,
+  worldIndex: any,
+  dungeonIndex: any,
+  minigameIndex: any
+) {
+  loading.value = true;
+  console.log("load minigame");
+  if (
+    isNaN(courseId) ||
+    isNaN(worldIndex) ||
+    isNaN(minigameIndex) ||
+    (dungeonIndex != undefined && isNaN(dungeonIndex))
+  ) {
+    loading.value = false;
+    console.log("one of the ids is NaN");
+    return;
+  }
+  getMinigame(courseId, worldIndex, dungeonIndex, minigameIndex)
+    .then(async (response) => {
+      const result: ITask = response.data;
+      minigame.value = result;
+      const promisessToWait = [
+        loadAverageSuccessChart(
+          courseId,
+          worldIndex,
+          dungeonIndex,
+          minigameIndex
+        ),
+      ];
+      await Promise.all(promisessToWait);
+    })
+    .catch((error) => {
+      console.log(error);
+      toast.error("There was an error loading the statistics!");
+    })
+    .finally(() => (loading.value = false));
+}
+
+async function loadAverageSuccessChart(
+  courseId: any,
+  worldIndex: any,
+  dungeonIndex: any,
+  minigameIndex: any
+) {
+  return getSuccessRateStatistic(
+    courseId,
+    worldIndex,
+    dungeonIndex,
+    minigameIndex
+  ).then((response) => {
+    const result = response.data;
+    const sumSuccessAt = 5;
+    let successHigherThanSuccessAt = 0;
+    let fails = 0;
+    let series = [] as Array<number>;
+    let labels = [] as Array<string>;
+    const greenColor = "#00FF00";
+    const redColor = "#FF0000";
+    let colors = [] as Array<string>;
+    for (let key in result.successRateDistribution) {
+      if (key < sumSuccessAt) {
+        series = [...series, result.successRateDistribution[key]];
+        labels = [...labels, `Beim ${key}. Versuch bestanden`];
+        colors = [...colors, greenColor];
+      } else {
+        successHigherThanSuccessAt += result.successRateDistribution[key];
+      }
+    }
+    if (successHigherThanSuccessAt > 0) {
+      series = [...series, successHigherThanSuccessAt];
+      labels = [...labels, `Bei ${sumSuccessAt}+. Versuch bestanden`];
+      colors = [...colors, greenColor];
+    }
+    for (let key in result.failureRateDistribution) {
+      fails += result.failureRateDistribution[key];
+    }
+    series = [...series, fails];
+    labels = [...labels, `Nicht bestanden`];
+    colors = [...colors, redColor];
+
+    successRatePieChart.value.series = series;
+    successRatePieChart.value.options = {
+      ...successRatePieChart.value.options,
+      ...{
+        title: { text: "Average Success" },
+        labels: labels,
+        colors: colors,
+      },
+    };
+  });
+}
+
+function goBack() {
+  router.go(-1);
+}
+
+loadMinigameStatistic(
+  courseId.value,
+  worldIndex.value,
+  dungeonIndex.value,
+  minigameIndex.value
+);
+
+const successRatePieChart = ref({
+  options: {
+    chart: { type: "pie" },
+    title: { text: "Average Success" },
+  } as ApexOptions,
+  series: [] as Array<number>,
+});
+</script>
+
+<template>
+  <b-overlay :show="loading" rounded="sm">
+    <div class="container mt-4">
+      <h1 v-if="dungeonIndex === undefined">
+        Minigame Statistic from Minigame {{ minigameIndex }} in World
+        {{ worldIndex }}
+      </h1>
+      <h1 v-else>
+        Minigame Statistic from Minigame {{ minigameIndex }} in World
+        {{ worldIndex }}, Dungeon {{ dungeonIndex }}
+      </h1>
+      <b-alert show dismissible>
+        Here, you can see the statistic if the current miningame.</b-alert
+      >
+      <apexchart
+        width="600"
+        :options="successRatePieChart.options"
+        :series="successRatePieChart.series"
+      ></apexchart>
+      <b-button @click="goBack">Back</b-button>
+    </div>
+  </b-overlay>
+</template>

--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -118,6 +118,8 @@ function goBack() {
 }
 
 const successRatePieChart = ref({
+  enoughDataToShow: true,
+  width: 600,
   options: {
     chart: { type: "pie" },
     title: { text: "Average Success" },
@@ -125,6 +127,8 @@ const successRatePieChart = ref({
   series: [] as Array<number>,
 });
 const highscoreDistributionRangeBar = ref({
+  enoughDataToShow: true,
+  width: 600,
   options: {
     chart: { type: "rangeBar" },
     title: { text: "Highscore Distribution" },
@@ -133,6 +137,18 @@ const highscoreDistributionRangeBar = ref({
     data: Array<{ x: string; y: Array<number> }>;
   }>,
 });
+
+const statistics = [
+  successRatePieChart,
+  highscoreDistributionRangeBar,
+] as Array<
+  Ref<{
+    enoughDataToShow: boolean;
+    width: number;
+    options: ApexOptions;
+    series: Array<any>;
+  }>
+>;
 
 loadMinigameStatistic(
   courseId.value,
@@ -156,22 +172,24 @@ loadMinigameStatistic(
       <b-alert show dismissible>
         Here, you can see the statistic if the current miningame.</b-alert
       >
+      <b-button @click="goBack">Back</b-button>
       <b-overlay :show="loadingGeneralStatistics" rounded="sm">
         <b-row id="general-statistics" class="container mt-4">
           <h2>General minigame statistics</h2>
-          <b-col>
-            <apexchart
-              width="600"
-              :options="successRatePieChart.options"
-              :series="successRatePieChart.series"
-            ></apexchart
-          ></b-col>
-          <b-col>
-            <apexchart
-              width="600"
-              :options="highscoreDistributionRangeBar.options"
-              :series="highscoreDistributionRangeBar.series"
-            ></apexchart>
+          <b-col
+            v-for="statistic of statistics"
+            :key="statistic.value.options.title"
+          >
+            <b-overlay :show="!statistic.value.enoughDataToShow" rounded="sm">
+              <apexchart
+                :width="statistic.value.width"
+                :options="statistic.value.options"
+                :series="statistic.value.series"
+              ></apexchart>
+              <template #overlay v-if="!loadingGeneralStatistics">
+                <h6>Statistic has not enough data to show.</h6>
+              </template>
+            </b-overlay>
           </b-col>
         </b-row>
       </b-overlay>
@@ -183,7 +201,6 @@ loadMinigameStatistic(
         Minigame specific statistics not included yet for this
         minigame.</b-alert
       >
-      <b-button @click="goBack">Back</b-button>
     </div>
   </b-overlay>
 </template>

--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -158,7 +158,7 @@ loadMinigameStatistic(
 
 <template>
   <b-overlay rounded="sm">
-    <div class="container mt-4">
+    <div class="container mt-4 mb-5">
       <h1 v-if="dungeonIndex === undefined">
         Minigame Statistic from Minigame {{ minigameIndex }} in World
         {{ worldIndex }}
@@ -167,6 +167,7 @@ loadMinigameStatistic(
         Minigame Statistic from Minigame {{ minigameIndex }} in World
         {{ worldIndex }}, Dungeon {{ dungeonIndex }}
       </h1>
+      <h3>{{ minigame.description }}</h3>
       <b-alert show dismissible>
         Here, you can see the statistic of the current miningame.</b-alert
       >

--- a/src/views/MinigameTasksView.vue
+++ b/src/views/MinigameTasksView.vue
@@ -15,6 +15,7 @@ import EditTowercrushConfigurationModal from "@/components/EditMinigameModals/Ed
 import EditCrosswordpuzzleModal from "@/components/EditMinigameModals/EditCrosswordpuzzleModal.vue";
 import MapImageModal from "@/components/MapImageModal.vue";
 import EditBugfinderConifgurationModal from "@/components/EditMinigameModals/EditBugfinderConifgurationModal.vue";
+import router from "@/router";
 
 const availableMinigames = Object.values(Minigame);
 
@@ -360,6 +361,29 @@ function closedEditModal() {
   showCrosswordpuzzleModal.value = false;
   showBugfinderModal.value = false;
 }
+
+function redirectToStatisticView(task: ITask) {
+  if (route.name?.toString().includes("world")) {
+    router.push({
+      name: "world-minigame-statistics",
+      params: {
+        courseId: courseId.value,
+        worldIndex: worldIndex.value,
+        minigameIndex: task.index,
+      },
+    });
+  } else {
+    router.push({
+      name: "dungeon-minigame-statistics",
+      params: {
+        courseId: courseId.value,
+        worldIndex: worldIndex.value,
+        dungeonIndex: dungeonIndex.value,
+        minigameIndex: task.index,
+      },
+    });
+  }
+}
 </script>
 
 <template>
@@ -415,6 +439,15 @@ function closedEditModal() {
             >
               <em class="bi bi-pencil-square"></em>
               Edit
+            </b-button>
+            <b-button
+              variant="warning"
+              size="small"
+              @click="redirectToStatisticView(task)"
+              :id="`redirectToStatistics` + task.index"
+            >
+              <em class="bi bi-pencil-square"></em>
+              Statistics
             </b-button>
           </b-col>
         </b-row>

--- a/src/views/MinigameTasksView.vue
+++ b/src/views/MinigameTasksView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ITask, Minigame, MapType } from "@/ts/models/overworld-models";
+import { ITask, MapType, Minigame } from "@/ts/models/overworld-models";
 import {
   getMinigames,
   putMinigame,

--- a/src/views/MinigameTasksView.vue
+++ b/src/views/MinigameTasksView.vue
@@ -430,7 +430,7 @@ function redirectToStatisticView(task: ITask) {
               @keydown.left.prevent
             ></b-form-select>
           </b-col>
-          <b-col sm="2">
+          <b-col sm="1">
             <b-button
               variant="info"
               size="small"
@@ -440,14 +440,15 @@ function redirectToStatisticView(task: ITask) {
               <em class="bi bi-pencil-square"></em>
               Edit
             </b-button>
+          </b-col>
+          <b-col sm="1">
             <b-button
               variant="warning"
               size="small"
               @click="redirectToStatisticView(task)"
               :id="`redirectToStatistics` + task.index"
             >
-              <em class="bi bi-pencil-square"></em>
-              Statistics
+              <em class="bi bi-graph-up"></em>
             </b-button>
           </b-col>
         </b-row>


### PR DESCRIPTION
Closes Gamify-IT/issues#433

Since Gamify-IT/issues#434 is not merged, the image version of the overworld-backend in docker-compose has to be changed to `feature-minigame-statistics`. To test start the docker compose with `docker compose up`, login as lecturer and go in the lecturer interface. On the minigame edit site you see statistic buttons on each minigame. 