### PR TITLE
Display minigame description on statistic page if minigame not undefined

### DIFF
--- a/src/views/MinigameTaskStatisticView.vue
+++ b/src/views/MinigameTaskStatisticView.vue
@@ -167,7 +167,7 @@ loadMinigameStatistic(
         Minigame Statistic from Minigame {{ minigameIndex }} in World
         {{ worldIndex }}, Dungeon {{ dungeonIndex }}
       </h1>
-      <h3>{{ minigame.description }}</h3>
+      <h3>{{ minigame?.description }}</h3>
       <b-alert show dismissible>
         Here, you can see the statistic of the current miningame.</b-alert
       >


### PR DESCRIPTION
Currently there is an error in the conolse, becuase the description of a minigame should be rendered. But in the beginning, the minigame is not loaded, so it can not access the description, because minigame is undefined.