### PR TITLE
Show the average in highscore distribution line chart

### DIFF
--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -101,7 +101,7 @@ export async function loadHighscoreDistributionInLineChart(
     const series = [{ name: "Players with score", data: data }];
     const average =
       result.reduce((current, next) => current + next.score * next.amount, 0) /
-      result.reduce((current, next) => current + next.score, 0);
+      result.reduce((current, next) => current + next.amount, 0);
 
     // at least one score has to be hit
     lineChart.enoughDataToShow =
@@ -128,9 +128,9 @@ export async function loadHighscoreDistributionInLineChart(
           curve: "smooth",
         },
         annotations: {
-          yaxis: [
+          xaxis: [
             {
-              y: average,
+              x: average,
               borderColor: "red",
               strokeDashArray: 0,
               label: {
@@ -139,7 +139,7 @@ export async function loadHighscoreDistributionInLineChart(
                   color: "#fff",
                   background: "red",
                 },
-                text: "Average",
+                text: "Average score",
               },
             },
           ],

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -115,8 +115,6 @@ export async function loadHighscoreDistributionInLineChart(
           title: {
             text: "Score",
           },
-          min: 0,
-          max: 100,
           type: "numeric",
         },
         yaxis: {

--- a/src/ts/statistics/overworld-statistics.ts
+++ b/src/ts/statistics/overworld-statistics.ts
@@ -99,9 +99,13 @@ export async function loadHighscoreDistributionInLineChart(
       data.push({ x: element.score, y: element.amount });
     });
     const series = [{ name: "Players with score", data: data }];
+    const average =
+      result.reduce((current, next) => current + next.score * next.amount, 0) /
+      result.reduce((current, next) => current + next.score, 0);
 
     // at least one score has to be hit
-    lineChart.enoughDataToShow = data.reduce((a, next) => a + next.y, 0) > 0;
+    lineChart.enoughDataToShow =
+      data.reduce((current, next) => current + next.y, 0) > 0;
 
     lineChart.series = series;
     lineChart.options = {
@@ -122,6 +126,23 @@ export async function loadHighscoreDistributionInLineChart(
         },
         stroke: {
           curve: "smooth",
+        },
+        annotations: {
+          yaxis: [
+            {
+              y: average,
+              borderColor: "red",
+              strokeDashArray: 0,
+              label: {
+                borderColor: "#999",
+                style: {
+                  color: "#fff",
+                  background: "red",
+                },
+                text: "Average",
+              },
+            },
+          ],
         },
       },
     };


### PR DESCRIPTION
In the [last review](https://github.com/Gamify-IT/docs/blob/b090ea6ba155750bbb6392e374dab843bc963fb5/protocols/2023-04-13-protocoll.md#lecturer-interface), it was requested to show a line in the highscore distribution line chart that shows the average of the highscore distribution.